### PR TITLE
Resolve deploy promise to deployed instance

### DIFF
--- a/src/actions/deploy.js
+++ b/src/actions/deploy.js
@@ -35,6 +35,7 @@ module.exports = function(contract, args, deployer) {
 
       // Ensure the address is set on the contract.
       contract.address = instance.address;
+      return instance;
     });
   };
 };


### PR DESCRIPTION
Allows deployed contract to be used in promise chain.

Before:
```javascript
deployer.deploy(MyContract)
  .then(() => MyContract.deployed())
  .then(instance => { // do something })
```

After:
```javascript
deployer.deploy(MyContract)
  .then(instance => { // do something })
```