### PR TITLE
Update tests for constructor arg validation

### DIFF
--- a/test/deployer.js
+++ b/test/deployer.js
@@ -1,4 +1,4 @@
-var TestRPC = require("ethereumjs-testrpc");
+var TestRPC = require("ganache-cli");
 var contract = require("truffle-contract");
 var Deployer = require("../index");
 var Web3 = require("web3");
@@ -72,7 +72,7 @@ describe("deployer", function() {
       from: accounts[0]
     });
 
-    deployer.deploy(Example);
+    deployer.deploy(Example, 1);
 
     return deployer.start().then(function() {
       assert.notEqual(Example.address, null);


### PR DESCRIPTION
Goes with  [truffle-contract PR 91](https://github.com/trufflesuite/truffle-contract/pull/91). Updates the tests here so they'll pass if we begin length checking the number args passed to a constructor.

Addresses issue [truffle-contract 82](https://github.com/trufflesuite/truffle-contract/issues/82).